### PR TITLE
Fix byte-compiler warnings and void variable access.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,9 @@ Todo
 Nothing planned.
 
 Changelog
+- 2021-05-04: v2.0.2
+Fix byte-compiler warnings and void variable access.
+
 - 2019-11-03: v2.0.0
 Reimplement browser synchronization in custom node server to drop dependency for browser-sync and support other platforms than os x. `C-c C-s d` to disconnect from browser. `C-c C-s p` to toggle presenter mode. Close the window when disconnecting from the slideshow on os x.
 

--- a/remark-mode.el
+++ b/remark-mode.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2015 Torgeir Thoresen
 
 ;; Author: @torgeir
-;; Version: 2.0.1
+;; Version: 2.0.2
 ;; Keywords: remark, slideshow, markdown, hot reload
 ;; Package-Requires: ((emacs "25.1") (markdown-mode "2.0"))
 


### PR DESCRIPTION
- Replace all use of interactive function by basic ones:
  - previous-line and next-line --> forward-line
  - beginning-of-buffer --> (goto-char (point-min))
  - end-of-buffer       --> (goto-char (point-max))
- Prevent warning about unused buffer-modified-p in remark-kill-browser by
  declaring an non-binding defvar for it.
- Prevent remark-mode from accessing a void markdown-mode-font-lock-keywords-basic
  variable by checking for it and using it only if it is bound, and using
  markdown-mode-font-lock-keywords otherwise.
- Instead of dynamically make-variable-buffer-local in remark-mode, changed
  the defvar of remark--last-cursor-pos and remark--last-move-timer to
  a defvar-local.  This macro was introduced in Emacs 24, since remark-mode
  advertises requiring Emacs 25.1, that should be ok.